### PR TITLE
Display a driver warning on macOS connection failure

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
         // In development we import locally.
         window.location.hostname === 'localhost'
           ? '/dist/web/nabucasa-zigbee-flasher.js'
-          : 'https://unpkg.com/@nabucasa/sl-web-tools@0.9.3/dist/web/nabucasa-zigbee-flasher.js?module'
+          : 'https://unpkg.com/@nabucasa/sl-web-tools@0.9.4/dist/web/nabucasa-zigbee-flasher.js?module'
       );
     </script>
   </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nabucasa/sl-web-tools",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nabucasa/sl-web-tools",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@material/mwc-button": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "WebSerial firmware flasher for Silicon Labs Zigbee radios",
   "license": "MIT",
   "author": "puddly",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "scripts": {
     "lint": "eslint --ext .ts,.html src --ignore-path .gitignore && prettier \"src/**/*.ts\" --check --ignore-path .gitignore",
     "format": "eslint --ext .ts,.html src --fix --ignore-path .gitignore && prettier \"src/**/*.ts\" --write --ignore-path .gitignore",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "puddly",
   "version": "0.9.3",
   "scripts": {
-    "lint": "eslint --ext .ts,.html . --ignore-path .gitignore && prettier \"**/*.ts\" --check --ignore-path .gitignore",
-    "format": "eslint --ext .ts,.html . --fix --ignore-path .gitignore && prettier \"**/*.ts\" --write --ignore-path .gitignore",
+    "lint": "eslint --ext .ts,.html src --ignore-path .gitignore && prettier \"src/**/*.ts\" --check --ignore-path .gitignore",
+    "format": "eslint --ext .ts,.html src --fix --ignore-path .gitignore && prettier \"src/**/*.ts\" --write --ignore-path .gitignore",
     "build": "script/build",
     "prepublishOnly": "npm run build",
     "analyze": "cem analyze --litelement"

--- a/src/flashing-dialog.ts
+++ b/src/flashing-dialog.ts
@@ -425,9 +425,9 @@ export class FlashingDialog extends LitElement {
                   >Silicon Labs CP2102 driver</a
                 >
                 and re-connect to the serial port titled
-                <code
+                <strong
                   >CP210x USB to UART Bridge Controller
-                  (cu.SLAB_USBtoUART)</code
+                  (cu.SLAB_USBtoUART)</strong
                 >. The other ports will not work!
               </p>
             </section>`

--- a/src/flashing-dialog.ts
+++ b/src/flashing-dialog.ts
@@ -10,7 +10,7 @@ import '@material/mwc-formfield';
 import '@material/mwc-radio';
 import '@material/mwc-dialog';
 
-import { mdiChip, mdiShimmer, mdiAutorenew, mdiClose } from '@mdi/js';
+import { mdiChip, mdiShimmer, mdiAutorenew, mdiClose, mdiAlert } from '@mdi/js';
 import './usf-icon';
 import './usf-icon-button';
 import './usf-file-upload';
@@ -113,6 +113,22 @@ export class FlashingDialog extends LitElement {
 
     td usf-icon {
       vertical-align: bottom;
+    }
+
+    section.warning {
+      border: 1px solid hsl(38deg, 98%, 85%);
+      border-radius: 1em;
+      padding: 1em;
+      background: hsl(38deg, 98%, 90%);
+      font-size: 0.9em;
+    }
+
+    section.warning h2 usf-icon {
+      vertical-align: text-bottom;
+    }
+
+    section.warning code {
+      font-weight: bold;
     }
   `;
 
@@ -389,8 +405,34 @@ export class FlashingDialog extends LitElement {
         </p>
       </p>`;
     } else if (this.flashingStep === FlashingStep.PROBING_FAILED) {
+      const isMacOS = navigator.userAgent.includes('Mac OS');
+      const isUsingCP210x = this.manifest.usb_filters.find(
+        filter => filter.vid == 4292 && filter.pid == 60000
+      );
+
       headingText = 'Connection failed';
-      content = html`<p>The running firmware could not be detected.</p>
+      content = html`${isMacOS && isUsingCP210x
+          ? html`<section class="warning">
+              <h2><usf-icon .icon=${mdiAlert}></usf-icon> macOS Driver Bug</h2>
+
+              <p>
+                The built-in drivers on macOS do not work properly with the
+                ${this.manifest.product_name}. Install the updated
+                <a
+                  href="https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers?tab=downloads"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  >Silicon Labs CP2102 driver</a
+                >
+                and re-connect to the serial port titled
+                <code
+                  >CP210x USB to UART Bridge Controller
+                  (cu.SLAB_USBtoUART)</code
+                >. The other ports will not work!
+              </p>
+            </section>`
+          : ''}
+        <p>The running firmware could not be detected.</p>
 
         <p>
           Make sure the USB port works and if you are using a USB extension

--- a/src/flashing-dialog.ts
+++ b/src/flashing-dialog.ts
@@ -116,11 +116,17 @@ export class FlashingDialog extends LitElement {
     }
 
     section.warning {
-      border: 1px solid hsl(38deg, 98%, 85%);
-      border-radius: 1em;
-      padding: 1em;
-      background: hsl(38deg, 98%, 90%);
+      background-color: hsl(38, 96%, 90%);
+
       font-size: 0.9em;
+
+      margin-left: -24px;
+      margin-right: -24px;
+
+      padding-left: 24px;
+      padding-right: 24px;
+      padding-top: 12px;
+      padding-bottom: 12px;
     }
 
     section.warning h2 usf-icon {
@@ -428,7 +434,7 @@ export class FlashingDialog extends LitElement {
                 <strong
                   >CP210x USB to UART Bridge Controller
                   (cu.SLAB_USBtoUART)</strong
-                >. The other ports will not work!
+                >.
               </p>
             </section>`
           : ''}


### PR DESCRIPTION
A warning will be shown on connection failure when the browser is running on macOS and when the manifest includes a SiLabs UART chip filter.

<p float="left">
<img width="49%" alt="image" src="https://user-images.githubusercontent.com/32534428/217941440-6181a60e-f8b7-40c0-adc1-7af7fa09417e.png"><img width="49%" alt="image" src="https://user-images.githubusercontent.com/32534428/217944513-dd27d1a1-4d58-41b7-9e9f-86b0d0b0bcac.png">
</p>