### PR TITLE
Update skyconnect.json with more consistant names

### DIFF
--- a/assets/manifests/skyconnect.json
+++ b/assets/manifests/skyconnect.json
@@ -14,22 +14,22 @@
 	],
 	"firmwares": [
 		{
-			"name": "Zigbee (EZSP)",
+			"name": "Zigbee EmberZNet (EZSP/Ember)",
 			"url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/EmberZNet/beta/NabuCasa_SkyConnect_EZSP_v7.1.4.0_ncp-uart-hw_115200.gbl",
 			"type": "ncp-uart-hw",
 			"version": "7.1.4.0"
 		},
-		{
-			"name": "Multi-PAN (RCP)",
-			"url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/RCPMultiPAN/NabuCasa_SkyConnect_RCP_v4.1.4_rcp-uart-hw-802154_115200.gbl",
-			"type": "rcp-uart-802154",
-			"version": "4.1.4"
-		},
-		{
-			"name": "OpenThread",
+    {
+			"name": "OpenThread RCP (Thread)",
 			"url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/OpenThreadRCP/NabuCasa_SkyConnect_OpenThread_RCP_v2.2.2.0_ot-rcp_hw_460800.gbl",
 			"type": "ot-rcp",
 			"version": "2.2.2.0"
+    },
+    {
+			"name": "RCP Multi-PAN (multiprotocol)",
+			"url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/RCPMultiPAN/NabuCasa_SkyConnect_RCP_v4.1.4_rcp-uart-hw-802154_115200.gbl",
+			"type": "rcp-uart-802154",
+			"version": "4.1.4"
 		}
 	],
 	"allow_custom_firmware_upload": true


### PR DESCRIPTION
Update skyconnect.json with more consistant names to match https://skyconnect.home-assistant.io/about-firmware-options/ and https://github.com/NabuCasa/silabs-firmware/tree/main and https://skyconnect.home-assistant.io/about-multiprotocol/ :

* "Zigbee EmberZNet (EZSP/Ember)"
* "OpenThread RCP (Thread)"
* "RCP Multi-PAN (multiprotocol)"

Also moved the "RCP Multi-PAN (multiprotocol)" option to the bottom now that is (actively) no longer recommended:

* https://www.home-assistant.io/blog/2024/01/25/matter-livestream-blog
 
_There is a third, experimental, firmware option that supports multiprotocol, which allows the Silicon Labs chip in these products to connect to both Zigbee and Thread networks with one radio. We announced our intent to release a firmware supporting multiprotocol when we launched Home Assistant Yellow and Home Assistant SkyConnect, and this firmware has been available since December 2022. It integrates the Silicon Labs SDK, which adds this support for multiprotocol. **During the further development and testing of the multiprotocol firmware, we have concluded that while Silicon Labs’ multiprotocol works, it comes with technical limitations. These limitations mean users will not have the best experience compared to using dedicated Zigbee and Thread radios. That is why we do not recommend using this firmware, and it will remain an experimental feature of Home Assistant Yellow and Home Assistant SkyConnect. If you currently have the multiprotocol firmware installed but don’t actively use it to connect to Thread devices, we recommend that you [disable multiprotocol](https://skyconnect.home-assistant.io/procedures/disable-multiprotocol/).**_

Here are references why added further compatibility info within the parenthesis to names as hints for users of other projects:

* Silicon Labs Zigbee stack/SDK is officially referred to as "Zigbee EmberZNet"+ they sometimes write it as "Ember ZNet":
  * https://www.silabs.com/developers/zigbee-emberznet
* "Ember"also because CLI for Zigbee EmberZNet is called "Ember" + is now also name for new adapter in Zigbee2MQTT:
  * https://github.com/Koenkk/zigbee-herdsman/pull/918
    * https://github.com/Koenkk/zigbee-herdsman/tree/master/src/adapter/ember
      * zigbee-herdsman will still keep their ezsp adapter for backward compatibility with older firmware versions:
        * https://github.com/Koenkk/zigbee-herdsman/tree/master/src/adapter/ezsp
* "Ember" is listed as well as Coordinaor CLI console compatibility for OpenHAB ZigBee Binding which supports SkyConnect:
  * https://www.openhab.org/addons/bindings/zigbee/#supported-coordinators
    * https://github.com/zsmartsystems/com.zsmartsystems.zigbee
* OpenThread RCP (Radio Co-Processor) firmware used for Home Assistant's (stable) OpenThread Border Router Add-on:
  * https://github.com/home-assistant/addons/tree/master/openthread_border_router
    * https://github.com/NabuCasa/silabs-firmware/tree/main
      * https://openthread.io/platforms/co-processor