### PR TITLE
Add repository to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,10 @@
       "prettier --write"
     ]
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NabuCasa/sl-web-tools"
+  },
   "customElements": "custom-elements.json",
   "overrides": {
     "minimatch": "5.1.2",


### PR DESCRIPTION
I believe this is the last bit of configuration we're missing for trusted publishing.